### PR TITLE
Fix new cluster manager

### DIFF
--- a/pkg/manager/aws/aws.go
+++ b/pkg/manager/aws/aws.go
@@ -63,7 +63,7 @@ func NewAWSClusterManager(ctx context.Context, clusterName string, profile strin
 
 	_ = log.FromContext(ctx)
 
-	//TODO: use something other than GetConfigOrDie, or mock this response
+	//TODO: use something other than GetConfigOrDie, or mock this response (this is just a regular function, not a method)
 	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
 	logrus.Print("Made it")
 	if err != nil {

--- a/pkg/manager/aws/aws.go
+++ b/pkg/manager/aws/aws.go
@@ -50,7 +50,7 @@ func NewAWSClusterManager(ctx context.Context, clusterName string, profile strin
 	if profile != "" {
 		cfg, err = config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
 		if err != nil {
-			err = errors.Wrapf(err, "failed creating aws config")
+			err = errors.Wrapf(err, "failed creating aws config with shared profile")
 			return am, err
 		}
 	} else {
@@ -63,7 +63,9 @@ func NewAWSClusterManager(ctx context.Context, clusterName string, profile strin
 
 	_ = log.FromContext(ctx)
 
+	//TODO: use something other than GetConfigOrDie, or mock this response
 	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
+	logrus.Print("Made it")
 	if err != nil {
 		err = errors.Wrapf(err, "failed creating k8s clients")
 		return am, err
@@ -188,4 +190,13 @@ func LoadBalancerName(clusterName string, lbType string) (lbName string, err err
 	}
 
 	return lbName, err
+}
+
+type dnsManager struct{}
+
+func (dnsManager) RegisterNode(ctx context.Context, node manager.ClusterNode, verbose bool) (err error) {
+	return err
+}
+func (dnsManager) DeregisterNode(ctx context.Context, nodeName string, verbose bool) (err error) {
+	return err
 }

--- a/pkg/manager/aws/aws_integration_test.go
+++ b/pkg/manager/aws/aws_integration_test.go
@@ -1,7 +1,10 @@
+//go:build integration
+
 package aws
 
 import (
 	"context"
+	"github.com/nikogura/k8s-cluster-manager/pkg/manager"
 	"log"
 	"os"
 	"testing"
@@ -33,6 +36,31 @@ func setUp() {
 	}
 
 	tmpDir = tdir
+
+	var awsProfile string
+	if ap, ok := os.LookupEnv("AWS_PROFILE"); ok {
+		awsProfile = ap
+	} //else {
+	//	log.Printf("%s not set\n", "AWS_PROFILE")
+	//	awsProfile = "blah"
+	//}
+
+	var clusterName string
+	if cn, ok := os.LookupEnv("CLUSTER_NAME"); ok {
+		clusterName = cn
+	} //else {
+	//	log.Printf("%s not set\n", "CLUSTER_NAME")
+	//	clusterName = "blee"
+	//}
+
+	dnsManager := manager.DNSManagerStruct{}
+
+	cm, err := NewAWSClusterManager(ctx, clusterName, awsProfile, dnsManager, true)
+	if err != nil {
+		log.Fatalf("couldn't create aws cluster manager: %s", err)
+	}
+
+	awsClusterManager = cm
 
 }
 

--- a/pkg/manager/aws/aws_test.go
+++ b/pkg/manager/aws/aws_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"github.com/nikogura/k8s-cluster-manager/pkg/manager"
 	"log"
 	"os"
 	"testing"
@@ -9,11 +10,13 @@ import (
 
 var awsClusterManager *AWSClusterManager
 var ctx context.Context
+
 var awsProfile string
 var clusterName string
 var tmpDir string
 
 func TestMain(m *testing.M) {
+
 	setUp()
 
 	code := m.Run()
@@ -33,10 +36,25 @@ func setUp() {
 
 	tmpDir = tdir
 
-	awsProfile = os.Getenv("AWS_PROFILE")
-	clusterName = os.Getenv("CLUSTER_NAME")
+	var awsProfile string
+	if ap, ok := os.LookupEnv("AWS_PROFILE"); ok {
+		awsProfile = ap
+	} //else {
+	//	log.Printf("%s not set\n", "AWS_PROFILE")
+	//	awsProfile = "blah"
+	//}
 
-	cm, err := NewAWSClusterManager(ctx, clusterName, awsProfile)
+	var clusterName string
+	if cn, ok := os.LookupEnv("CLUSTER_NAME"); ok {
+		clusterName = cn
+	} //else {
+	//	log.Printf("%s not set\n", "CLUSTER_NAME")
+	//	clusterName = "blee"
+	//}
+
+	dnsManager := manager.DNSManagerStruct{}
+
+	cm, err := NewAWSClusterManager(ctx, clusterName, awsProfile, dnsManager, true)
 	if err != nil {
 		log.Fatalf("Couldn't create aws cluster manager: %s", err)
 	}
@@ -47,6 +65,8 @@ func setUp() {
 
 func tearDown() {
 	if _, err := os.Stat(tmpDir); err == nil {
-		os.RemoveAll(tmpDir)
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Fatalf("couldn't remove temporary directory: %s", err)
+		}
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -48,6 +48,15 @@ type DNSManager interface {
 	DeregisterNode(ctx context.Context, nodeName string, verbose bool) (err error)
 }
 
+type DNSManagerStruct struct{}
+
+func (DNSManagerStruct) RegisterNode(ctx context.Context, node ClusterNode, verbose bool) (err error) {
+	return err
+}
+func (DNSManagerStruct) DeregisterNode(ctx context.Context, nodeName string, verbose bool) (err error) {
+	return err
+}
+
 type ClusterInfo struct {
 	Name                       string
 	Provider                   string


### PR DESCRIPTION
We need two `TestMain()` functions, one for unit and one for integration. The `NewAWSClusterManager()` function is only needed for the integration setup (though it can be, itself, unit tested....future PR forthcoming).