### PR TITLE
More mocks and some test failure utility functions

### DIFF
--- a/pkg/manager/aws/aws.go
+++ b/pkg/manager/aws/aws.go
@@ -29,23 +29,46 @@ func init() {
 	logrus.SetLevel(logrus.DebugLevel)
 }
 
+//type AWSClusterManager struct {
+//	Name                       string
+//	cloudProviderName          string
+//	k8sProviderName            string
+//	scheduleWorkloadsOnCPNodes bool
+//	Domain                     string
+//	DnsManager                 manager.DNSManager
+//	GetVerbose                    bool
+//	Config                     aws.Config
+//	//TODO: delete the literal ec2 client after mocks are complete
+//	Ec2ClientLiteral   *ec2.Client
+//	Ec2Client          Ec2Client
+//	ELBClient          ELBClient
+//	Context            context.Context
+//	Profile            string
+//	KubeClient         client.Client
+//	FetchedNodesById   map[string]manager.NodeInfo
+//	FetchedNodesByName map[string]manager.NodeInfo
+//	ClusterNameRegex   *regexp.Regexp
+//}
+
 type AWSClusterManager struct {
 	Name                       string
-	cloudProviderName          string
-	k8sProviderName            string
-	scheduleWorkloadsOnCPNodes bool
-	domain                     string
-	dnsManager                 manager.DNSManager
-	verbose                    bool
+	CloudProviderName          string
+	K8sProviderName            string
+	ScheduleWorkloadsOnCPNodes bool
+	Domain                     string
+	DnsManager                 manager.DNSManager
+	Verbose                    bool
 	Config                     aws.Config
-	Ec2Client                  *ec2.Client
-	ELBClient                  ELBClient
-	Context                    context.Context
-	Profile                    string
-	KubeClient                 client.Client
-	FetchedNodesById           map[string]manager.NodeInfo
-	FetchedNodesByName         map[string]manager.NodeInfo
-	ClusterNameRegex           *regexp.Regexp
+	//TODO: delete the literal ec2 client after mocks are complete
+	//Ec2ClientLiteral   *ec2.Client
+	Ec2Client          Ec2Client
+	ELBClient          ELBClient
+	Context            context.Context
+	Profile            string
+	KubeClient         client.Client
+	FetchedNodesById   map[string]manager.NodeInfo
+	FetchedNodesByName map[string]manager.NodeInfo
+	ClusterNameRegex   *regexp.Regexp
 }
 
 func NewAWSClusterManager(ctx context.Context, clusterName string, profile string, role string, dnsManager manager.DNSManager, verbose bool) (am *AWSClusterManager, err error) {
@@ -111,10 +134,10 @@ func NewAWSClusterManager(ctx context.Context, clusterName string, profile strin
 
 	am = &AWSClusterManager{
 		Name:               clusterName,
-		cloudProviderName:  "aws",
-		k8sProviderName:    "talos",
-		dnsManager:         dnsManager,
-		verbose:            verbose,
+		CloudProviderName:  "aws",
+		K8sProviderName:    "talos",
+		DnsManager:         dnsManager,
+		Verbose:            verbose,
 		Config:             cfg,
 		Ec2Client:          ec2Client,
 		ELBClient:          elbClient,
@@ -133,25 +156,24 @@ func (am *AWSClusterManager) ClusterName() string {
 	return am.Name
 }
 
-func (am *AWSClusterManager) CloudProviderName() string {
-	return am.cloudProviderName
+//	func (am *AWSClusterManager) CloudProviderName() string {
+//		return am.CloudProviderName
+//	}
+//
+//	func (am *AWSClusterManager) K8sProviderName() string {
+//		return am.K8sProviderName
+//	}
+func (am *AWSClusterManager) GetScheduleWorkloadsOnCPNodes() bool {
+	return am.ScheduleWorkloadsOnCPNodes
+}
+func (am *AWSClusterManager) GetVerbose() bool {
+	return am.Verbose
 }
 
-func (am *AWSClusterManager) K8sProviderName() string {
-	return am.k8sProviderName
-}
-
-func (am *AWSClusterManager) ScheduleWorkloadsOnCPNodes() bool {
-	return am.scheduleWorkloadsOnCPNodes
-}
-
-func (am *AWSClusterManager) Verbose() bool {
-	return am.verbose
-}
-
-func (am *AWSClusterManager) DNSManager() manager.DNSManager {
-	return am.dnsManager
-}
+//
+//func (am *AWSClusterManager) DNSManager() manager.DNSManager {
+//	return am.DnsManager
+//}
 
 func (am *AWSClusterManager) DescribeCluster(clusterName string) (info manager.ClusterInfo, err error) {
 

--- a/pkg/manager/aws/ec2_test.go
+++ b/pkg/manager/aws/ec2_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"github.com/nikogura/k8s-cluster-manager/pkg/manager"
 	"github.com/stretchr/testify/assert"
 	"reflect"
@@ -58,7 +57,7 @@ func TestGetNode(t *testing.T) {
 		expect expect
 	}{
 		{
-			name: "Get Node - One Running Instance",
+			name: "ACM.GetNode() - One Running Instance",
 			acm: AWSClusterManager{
 				Ec2Client:          MockEc2ClientOneRunningInst{},
 				FetchedNodesByName: make(map[string]manager.NodeInfo),
@@ -87,16 +86,16 @@ func TestGetNode(t *testing.T) {
 			},
 		},
 		{
-			name: "Get Node - Stopped Instance",
+			name: "ACM.GetNode() - Stopped Instance",
 			acm: AWSClusterManager{
-				Ec2Client:          MockEc2ClientOneRunningInst{},
+				Ec2Client:          MockEc2ClientStoppedInst{},
 				FetchedNodesByName: make(map[string]manager.NodeInfo),
 				FetchedNodesById:   make(map[string]manager.NodeInfo),
 			},
 			expect: expect{
 				manager.NodeInfo{},
 				AWSClusterManager{
-					Ec2Client:          MockEc2ClientOneRunningInst{},
+					Ec2Client:          MockEc2ClientStoppedInst{},
 					FetchedNodesByName: make(map[string]manager.NodeInfo),
 					FetchedNodesById:   make(map[string]manager.NodeInfo),
 				},
@@ -114,39 +113,14 @@ func TestGetNode(t *testing.T) {
 			if e, g := tc.expect.ni, got; reflect.DeepEqual(e, g) != true {
 				eStr := prettyPrint(e)
 				gStr := prettyPrint(g)
-				t.Errorf("\n expect:\n%s\n got:\n%s", eStr, gStr)
+				t.Errorf("\n expect:\n%s\n got:\n%s\n", eStr, gStr)
 			}
 			if e, g := tc.expect.acm, tc.acm; reflect.DeepEqual(e, g) != true {
 				eStr := prettyPrint(e)
 				gStr := prettyPrint(g)
-				t.Logf("\n expect:\n%s\n got:\n%s", eStr, gStr)
-				t.Errorf("\n maps:\n expect:\n%s\n got:\n%s", prettyPrintMap(tc.expect.acm.FetchedNodesByName), prettyPrintMap(tc.acm.FetchedNodesByName))
+				t.Logf("\n expect:\n%s\n got:\n%s\n", eStr, gStr)
+				t.Errorf("\n expect (maps):\n%s\n got:\n%s\n", prettyPrintMap(tc.expect.acm.FetchedNodesByName), prettyPrintMap(tc.acm.FetchedNodesByName))
 			}
 		})
 	}
-}
-
-func prettyPrint[T any](str T) string {
-	s := reflect.ValueOf(&str).Elem()
-	typeOf := s.Type()
-	pretty := ""
-	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i)
-		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s %s = %v\n", i,
-			typeOf.Field(i).Name, f.Type(), f.Interface())}, "")
-	}
-
-	return pretty
-}
-
-func prettyPrintMap[T map[string]manager.NodeInfo](str T) string {
-	pretty := ""
-	i := 0
-	for k, v := range str {
-		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s =\n-\n|\n%s\n", i,
-			k, prettyPrint(v))}, "")
-		i++
-	}
-
-	return pretty
 }

--- a/pkg/manager/aws/ec2_test.go
+++ b/pkg/manager/aws/ec2_test.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"fmt"
+	"github.com/nikogura/k8s-cluster-manager/pkg/manager"
 	"github.com/stretchr/testify/assert"
+	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -39,4 +44,109 @@ func TestLoadNodeName(t *testing.T) {
 		}
 		assert.Equal(t, tc.expected, actual, "actual load balancer name does not meet expectations")
 	}
+}
+
+func TestGetNode(t *testing.T) {
+	type expect struct {
+		ni  manager.NodeInfo
+		acm AWSClusterManager
+	}
+
+	testCases := []struct {
+		name   string
+		acm    AWSClusterManager
+		expect expect
+	}{
+		{
+			name: "Get Node - One Running Instance",
+			acm: AWSClusterManager{
+				Ec2Client:          MockEc2ClientOneRunningInst{},
+				FetchedNodesByName: make(map[string]manager.NodeInfo),
+				FetchedNodesById:   make(map[string]manager.NodeInfo),
+			},
+			expect: expect{
+				manager.NodeInfo{
+					Name: NODENAME,
+					ID:   INSTANCEID,
+				},
+				AWSClusterManager{
+					Ec2Client: MockEc2ClientOneRunningInst{},
+					FetchedNodesByName: map[string]manager.NodeInfo{
+						NODENAME: {
+							Name: NODENAME,
+							ID:   INSTANCEID,
+						},
+					},
+					FetchedNodesById: map[string]manager.NodeInfo{
+						INSTANCEID: {
+							Name: NODENAME,
+							ID:   INSTANCEID,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Get Node - Stopped Instance",
+			acm: AWSClusterManager{
+				Ec2Client:          MockEc2ClientOneRunningInst{},
+				FetchedNodesByName: make(map[string]manager.NodeInfo),
+				FetchedNodesById:   make(map[string]manager.NodeInfo),
+			},
+			expect: expect{
+				manager.NodeInfo{},
+				AWSClusterManager{
+					Ec2Client:          MockEc2ClientOneRunningInst{},
+					FetchedNodesByName: make(map[string]manager.NodeInfo),
+					FetchedNodesById:   make(map[string]manager.NodeInfo),
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strings.Join([]string{strconv.Itoa(i + 1), tc.name}, "."), func(t *testing.T) {
+			got, err := tc.acm.GetNode(NODENAME)
+
+			if err != nil {
+				t.Fatalf("no error expected with mocks, got %+v", err)
+			}
+			if e, g := tc.expect.ni, got; reflect.DeepEqual(e, g) != true {
+				eStr := prettyPrint(e)
+				gStr := prettyPrint(g)
+				t.Errorf("\n expect:\n%s\n got:\n%s", eStr, gStr)
+			}
+			if e, g := tc.expect.acm, tc.acm; reflect.DeepEqual(e, g) != true {
+				eStr := prettyPrint(e)
+				gStr := prettyPrint(g)
+				t.Logf("\n expect:\n%s\n got:\n%s", eStr, gStr)
+				t.Errorf("\n maps:\n expect:\n%s\n got:\n%s", prettyPrintMap(tc.expect.acm.FetchedNodesByName), prettyPrintMap(tc.acm.FetchedNodesByName))
+			}
+		})
+	}
+}
+
+func prettyPrint[T any](str T) string {
+	s := reflect.ValueOf(&str).Elem()
+	typeOf := s.Type()
+	pretty := ""
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s %s = %v\n", i,
+			typeOf.Field(i).Name, f.Type(), f.Interface())}, "")
+	}
+
+	return pretty
+}
+
+func prettyPrintMap[T map[string]manager.NodeInfo](str T) string {
+	pretty := ""
+	i := 0
+	for k, v := range str {
+		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s =\n-\n|\n%s\n", i,
+			k, prettyPrint(v))}, "")
+		i++
+	}
+
+	return pretty
 }

--- a/pkg/manager/aws/ec2mock.go
+++ b/pkg/manager/aws/ec2mock.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+const INSTANCEID = "i-0af01c0123456789a"
+const NODENAME = "test-cp-1"
+
+type Ec2Client interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
+	TerminateInstances(ctx context.Context, params *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+//var blah = ec2.Client.DescribeSecurityGroups
+
+type MockEc2ClientOneRunningInst struct {
+	*ec2.Client
+}
+
+//var blah = ec2.Client.DescribeInstances(ctx, blah)
+
+func (MockEc2ClientOneRunningInst) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						State:      &types.InstanceState{Name: types.InstanceStateNameRunning},
+						InstanceId: aws.String(INSTANCEID),
+						Tags: []types.Tag{
+							{
+								Key:   aws.String("Name"),
+								Value: aws.String(NODENAME),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type MockEc2ClientStoppedInst struct {
+	*ec2.Client
+}
+
+//var blah = ec2.Client.DescribeInstances(ctx, blah)
+
+func (MockEc2ClientStoppedInst) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						State:      &types.InstanceState{Name: types.InstanceStateNameStopped},
+						InstanceId: aws.String(INSTANCEID),
+						Tags: []types.Tag{
+							{
+								Key:   aws.String("Name"),
+								Value: aws.String(NODENAME),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/manager/aws/elb.go
+++ b/pkg/manager/aws/elb.go
@@ -172,7 +172,7 @@ func (am *AWSClusterManager) UpdateLB() (err error) {
 */
 
 func (am *AWSClusterManager) DeRegisterNode(nodeName string, nodeID string) (err error) {
-	manager.VerboseOutput(am.Verbose(), "Deregistering node %s from load balancers in cluster %s \n", nodeName, am.ClusterName())
+	manager.VerboseOutput(am.GetVerbose(), "Deregistering node %s from load balancers in cluster %s \n", nodeName, am.ClusterName())
 
 	lbs, err := am.GetClusterLBs()
 	if err != nil {
@@ -184,7 +184,7 @@ func (am *AWSClusterManager) DeRegisterNode(nodeName string, nodeID string) (err
 	for _, lb := range lbs {
 		for _, tg := range lb.TargetGroups {
 			// Register the node in the TargetGroup
-			manager.VerboseOutput(am.Verbose(), "Degistering Node %s with Target Group %s on Port %d\n", nodeName, tg.Arn, tg.Port)
+			manager.VerboseOutput(am.GetVerbose(), "Degistering Node %s with Target Group %s on Port %d\n", nodeName, tg.Arn, tg.Port)
 			err = am.DeregisterTarget(tg.Arn, nodeID, tg.Port)
 			if err != nil {
 				err = errors.Wrapf(err, "failed deregistering %s on tg %s", nodeName, tg.Arn)
@@ -219,7 +219,7 @@ func (am *AWSClusterManager) DeregisterTarget(tgARN string, nodeID string, port 
 }
 
 func (am *AWSClusterManager) RegisterNode(node manager.ClusterNode) (err error) {
-	manager.VerboseOutput(am.Verbose(), "Registering Node %s with role %s\n", node.Name(), node.Role())
+	manager.VerboseOutput(am.GetVerbose(), "Registering Node %s with role %s\n", node.Name(), node.Role())
 
 	lbs, err := am.GetClusterLBs()
 	if err != nil {
@@ -235,14 +235,14 @@ func (am *AWSClusterManager) RegisterNode(node manager.ClusterNode) (err error) 
 		}
 
 		// If it's not an apiserver LB, and this is a CP node, and we don't schedule workloads here, move on
-		if !lb.IsApiServer && node.Role() == manager.NODE_ROLE_CP && !am.ScheduleWorkloadsOnCPNodes() {
+		if !lb.IsApiServer && node.Role() == manager.NODE_ROLE_CP && !am.GetScheduleWorkloadsOnCPNodes() {
 			continue // skip registration
 		}
 
 		// Register the node.
 		for _, tg := range lb.TargetGroups {
 			// Register the node in the TargetGroup
-			manager.VerboseOutput(am.Verbose(), "Registering Node %s with Target Group %s on Port %d\n", node.ID(), tg.Arn, tg.Port)
+			manager.VerboseOutput(am.GetVerbose(), "Registering Node %s with Target Group %s on Port %d\n", node.ID(), tg.Arn, tg.Port)
 			err = am.RegisterTarget(tg.Arn, node.ID(), tg.Port)
 			if err != nil {
 				err = errors.Wrapf(err, "failed registering %s on tg %s", node.ID(), tg.Arn)

--- a/pkg/manager/aws/types.go
+++ b/pkg/manager/aws/types.go
@@ -14,7 +14,7 @@ type AWSNodeConfig struct {
 	BlockDeviceName    string `yaml:"block_device_name"`
 	BlockDeviceType    string `yaml:"block_device_type"`
 	PlacementGroupName string `yaml:"placement_group_name"`
-	Domain             string `yaml:"domain"`
+	Domain             string `yaml:"Domain"`
 }
 
 type AWSNode struct {
@@ -23,7 +23,7 @@ type AWSNode struct {
 	NodeRole   string         `yaml:"role"`
 	NodeID     string         `yaml:"id"`
 	Config     *AWSNodeConfig `yaml:"config"`
-	NodeDomain string         `yaml:"domain"`
+	NodeDomain string         `yaml:"Domain"`
 }
 
 func (n AWSNode) Name() (nodeName string) {

--- a/pkg/manager/aws/utilities.go
+++ b/pkg/manager/aws/utilities.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/nikogura/k8s-cluster-manager/pkg/manager"
+	"reflect"
+	"strings"
+)
+
+func prettyPrint[T any](str T) string {
+	s := reflect.ValueOf(&str).Elem()
+	typeOf := s.Type()
+	pretty := ""
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s %s = %v\n", i,
+			typeOf.Field(i).Name, f.Type(), f.Interface())}, "")
+	}
+
+	return pretty
+}
+
+func prettyPrintMap[T map[string]manager.NodeInfo](str T) string {
+	pretty := ""
+	i := 0
+	for k, v := range str {
+		pretty = strings.Join([]string{pretty, fmt.Sprintf("%d: %s =\n-\n | values for key %d:\n%s\n", i,
+			k, i, prettyPrint(v))}, "")
+		i++
+	}
+
+	return pretty
+}


### PR DESCRIPTION
Exported all fields in the cluster manager to allow `DeepEqual` to work (it panics on unexported fields).